### PR TITLE
Fixes a potential project path bug and adds ability to set a different output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Press Ctrl+C to stop.
 
 Left to the defaults, this will search `./templates` recursively for any templates and build them to `.`, ignoring any files that start with `_` or `.`. Furthermore, if you go on to change a template, it will automatically recompile it.
 
+# Basic Configuration
+
+### Templates and output directories
+
+To set a different templates directory, use the `searchpath="templated_dir_name"` keyword argument to `staticjinja.main()` (default is `templates`, inside the directory of `build.py`).
+
+To set a different output directory, use the `outpath="output_dir"` (default is the directory of `build.py`).
 
 # Advanced Configuration
 


### PR DESCRIPTION
This fixes a potential project path problem. In:

```
mod = inspect.getmodule(inspect.stack()[1][0])
```

there should be `inspect.stack()[-1][0]`, otherwise it doesn't work when someone calls `build.py` from other script or when running it in the debugger (the Python debugger inserts its things into the stack...).

I also added the ability to specify a different output dir (via an `outpath` argument to `staticjinja.main()`) and documented this in the README.
