### PR TITLE
Automated dependency management

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
-from staticjinja import __version__
-
+__version_info__ = ('0', '0', '7')
+__version__ = '.'.join(__version_info__)
 
 setup(
     name="staticjinja",
@@ -12,6 +12,7 @@ setup(
     url="https://github.com/Ceasar/staticjinja",
     keywords=["jinja", "static", "website"],
     packages=["staticjinja"],
+    install_requires=["easywatch", "jinja2"],
     classifiers=[
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",

--- a/staticjinja/__init__.py
+++ b/staticjinja/__init__.py
@@ -1,4 +1,1 @@
-__version_info__ = ('0', '0', '7')
-__version__ = '.'.join(__version_info__)
-
 from staticjinja import *


### PR DESCRIPTION
together with the pull request outstanding to easywatch, this will allow a user to "pip install staticjinja" without first manually installing dependencies. Both the new version of easywatch and staticjinja must be published to pypi for this to work, though. 
