### PR TITLE
Add a CLI tool, staticjinja, in place of __main__

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ extensible, enabling you to focus on simply making your site.
 
     $ mkdir templates
     $ vim templates/index.html
-    $ python -m staticjinja
+    $ staticjinja watch
     Building index.html...
     Templates built.
     Watching 'templates' for changes...

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1,8 +1,100 @@
-
 Advanced Usage
 ==============
 
 This document covers some of staticjinja's more advanced features.
+
+.. _custom-build-scripts:
+
+Using Custom Build Scripts
+--------------------------
+
+The command line shortcut is convenient, but sometimes your project
+needs something different than the defaults. To change them, you can
+use a build script.
+
+A minimal build script looks something like this:
+
+.. code-block:: python
+
+    from staticjinja import make_renderer
+
+
+    if __name__ == "__main__":
+        renderer = make_renderer()
+        # enable automatic reloading
+        renderer.run(use_reloader=True)
+
+To change behavior, pass the appropriate keyword arguments to
+``make_renderer``.
+
+* To change which directory to search for templates, set
+  ``searchpath="searchpath_name"`` (default is ``./templates``).
+* To change the output directory, pass in ``outpath="output_dir"``
+  (default is ``.``).
+* To add Jinja extensions, pass in ``extensions=[extension1,
+  extension2, ...]``.
+* To change which files are considered templates, subclass the
+  ``Renderer`` object and override ``is_template``.
+* To change where static files (such as CSS or JavaScript) are stored,
+  set ``staticpath="mystaticfiles"`` (the default is ``None``, which
+  means no files are considered to be static files).
+
+Finally, just save the script as ``build.py`` (or something similar)
+and run it with your Python interpreter.
+
+.. code-block:: bash
+
+    $ python build.py
+    Building index.html...
+    Templates built.
+    Watching 'templates' for changes...
+    Press Ctrl+C to stop.
+
+
+Loading data
+------------
+
+Some applications render templates based on data sources (e.g. CSVs or
+JSON files).
+
+To get data to templates you can set up a mapping between filenames
+and functions which generate dictionaries containing the data:
+
+.. code-block:: python
+
+    from staticjinja import make_renderer
+
+    def get_knights():
+        """Generate knights of the round table."""
+        knights = [
+            'sir arthur',
+            'sir lancelot',
+            'sir galahad',
+        ]
+        return {'knights': knights}
+
+    if __name__ == "__main__":
+        renderer = make_renderer(contexts=[
+            ('index.html', get_knights),
+        ])
+        renderer.run(use_reloader=True)
+
+You can then use the data in ``templates/index.html`` as you'd expect.
+
+.. code-block:: html
+
+    <!-- templates/index.html -->
+    {% extends "_base.html" %}
+    {% block body %}
+    <h1>Hello world!</h1>
+    <p>This is an example web page.</p>
+    <h3>Knights of the Round Table</h3>
+    <ul>
+    {% for knight in knights }}
+        <li>{{ knight }}</li>
+    {% endfor %}
+    </ul>
+    {% endblock %}
 
 Compilation rules
 -----------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -1,8 +1,8 @@
 Quickstart
 ==========
 
-Eager to get started? This page gives a good introduction in how to
-get started with staticjinja.
+Eager to get started? This page gives a good introduction for getting
+started with staticjinja.
 
 Installation
 ------------
@@ -22,106 +22,37 @@ get up and running with the following shortcut:
 
 .. code-block:: bash
 
-   $ python -m staticjinja
-    Building index.html...
-    Templates built.
-    Watching 'templates' for changes...
-    Press Ctrl+C to stop.
+   $ staticjinja build
+    Rendering index.html...
 
 This will recursively search ``./templates`` for templates (any file
 whose name does not start with ``.`` or ``_``) and build them to
 ``.``.
 
-If ``easywatch`` is installed, this will also monitor the files in
-`./templates` and recompile them if they change.
-
-
-Basic configuration
--------------------
-
-The command line shortcut is convenient, but sometimes your project
-needs something different than the defaults. To change them, you can
-use a build script.
-
-A minimal build script looks something like this:
-
-.. code-block:: python
-
-    from staticjinja import make_renderer
-
-
-    if __name__ == "__main__":
-        renderer = make_renderer()
-        # enable automatic reloading
-        renderer.run(use_reloader=True)
-
-To change behavior, pass the appropriate keyword arguments to
-``make_renderer``.
-
-* To change which directory to search for templates, set
-  ``searchpath="searchpath_name"`` (default is ``./templates``).
-* To change the output directory, pass in ``outpath="output_dir"``
-  (default is ``.``).
-* To add Jinja extensions, pass in ``extensions=[extension1,
-  extension2, ...]``.
-* To change which files are considered templates, subclass the
-  ``Renderer`` object and override ``is_template``.
-* To change where static files (such as CSS or JavaScript) are stored,
-  set ``staticpath="mystaticfiles"`` (default is ``./static``).
-
-Finally, just save the script as ``build.py`` (or something similar)
-and run it with your Python interpreter.
+To monitor your source directory for changes, and recompile files if
+they change, use ``watch``:
 
 .. code-block:: bash
 
-    $ python build.py
-    Building index.html...
-    Templates built.
+   $ staticjinja watch
+    Rendering index.html...
     Watching 'templates' for changes...
     Press Ctrl+C to stop.
 
+Configuration
+-------------
 
-Loading data
-------------
+``build`` and ``watch`` each take 3 options:
 
-Some applications render templates based on data sources (e.g. CSVs or
-JSON files).
+* ``--srcpath`` - the directory to look in for templates (defaults to
+  ``./templates``);
+* ``--outpath`` - the directory to place rendered files in (defaults
+  to ``.``);
+* ``--static`` - the directory within ``srcpath`` where static files
+  (such as CSS and JavaScript) are stored. Static files are copied to
+  the output directory without any template compilation, maintaining
+  any directory structure. This defaults to ``None``, meaning no files
+  are considered to be static files.
 
-To get data to templates you can set up a mapping between filenames
-and functions which generate dictionaries containing the data:
-
-.. code-block:: python
-
-    from staticjinja import make_renderer
-
-    def get_knights():
-        """Generate knights of the round table."""
-        knights = [
-            'sir arthur',
-            'sir lancelot',
-            'sir galahad',
-        ]
-        return {'knights': knights}
-
-    if __name__ == "__main__":
-        renderer = make_renderer(contexts=[
-            ('index.html', get_knights),
-        ])
-        renderer.run(use_reloader=True)
-
-You can then use the data in ``templates/index.html`` as you'd expect.
-
-.. code-block:: html
-
-    <!-- templates/index.html -->
-    {% extends "_base.html" %}
-    {% block body %}
-    <h1>Hello world!</h1>
-    <p>This is an example web page.</p>
-    <h3>Knights of the Round Table</h3>
-    <ul>
-    {% for knight in knights }}
-        <li>{{ knight }}</li>
-    {% endfor %}
-    </ul>
-    {% endblock %}
+More advanced configuration can be done using the staticjinja API, see
+:ref:`custom-build-scripts` for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Jinja2==2.6
 PyYAML==3.10
 argh==0.21.0
 argparse==1.2.1
+docopt==0.6.1
 easywatch==0.0.2
 pathtools==0.1.2
 watchdog==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,16 @@ setup(
     url="https://github.com/Ceasar/staticjinja",
     keywords=["jinja", "static", "website"],
     packages=["staticjinja"],
-    install_requires=["easywatch", "jinja2"],
+    entry_points={
+        'console_scripts': [
+            'staticjinja = staticjinja.cli:main',
+        ],
+    },
+    install_requires=[
+        "docopt",
+        "easywatch",
+        "jinja2",
+    ],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+"""staticjinja
+
+Usage:
+  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<static>]
+  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<static>]
+  staticjinja (-h | --help)
+  staticjinja --version
+
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+
+"""
+from __future__ import print_function
+from docopt import docopt
+import os
+import staticjinja
+import sys
+
+
+def main():
+    arguments = docopt(__doc__, version='staticjinja 0.2.0')
+
+    if arguments['--srcpath'] is not None:
+        srcpath = arguments['--srcpath']
+    else:
+        srcpath = os.path.join(os.getcwd(), 'templates')
+
+    if not os.path.isdir(srcpath):
+        print("The templates directory '%s' is invalid."
+              % srcpath)
+        sys.exit(1)
+
+    if arguments['--outpath'] is not None:
+        outpath = arguments['--outpath']
+    else:
+        outpath = os.getcwd()
+
+    if not os.path.isdir(outpath):
+        print("The output directory '%s' is invalid."
+              % outpath)
+        sys.exit(1)
+
+    staticdir = arguments['--static']
+    staticpath = None
+
+    if staticdir:
+        staticpath = os.path.join(srcpath, staticdir)
+
+    if staticpath and not os.path.isdir(staticpath):
+        print("The static files directory '%s' is invalid."
+              % staticpath)
+        sys.exit(1)
+
+    renderer = staticjinja.make_renderer(
+        searchpath=srcpath,
+        outpath=outpath,
+        staticpath=staticdir
+    )
+
+    use_reloader = arguments['watch']
+
+    renderer.run(use_reloader=use_reloader)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
python -m staticjinja is still supported, but this tool
takes options for the source path, the output directory, and
static files.

Users wishing to pass in particular data will still need a
custom build script.
