### PR TITLE
--srcmask CLI option & searchmask argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,124 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### Python Patch ###
+.venv/
+
+
 *.py[co]
 
 # Packages
@@ -30,3 +151,58 @@ pip-log.txt
 /*.html
 
 docs/_build
+
+# Automatically created by GitHub for Mac
+# To make edits, delete these initial comments, or else your changes may be lost!
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea
+# CMake
+cmake-build-*/
+
+
+# File-based project format
+*.iws
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -242,15 +242,16 @@ you want to handle, and a compilation function (a "rule").
     # compilation rule
     def render_post(env, template, **kwargs):
         """Render a template as a post."""
+        directory, fname = os.path.split(template.name)
+        post_title, _ = fname.split(".")
+        post_fname = "%s.html" % post_title
+
+        out_dir = os.path.join(env.outpath, directory)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        out = os.path.join(out_dir, post_fname)
+
         post_template = env.get_template("_post.html")
-        head, tail = os.path.split(post_template.name)
-        post_title, _ = tail.split('.')
-        if head:
-            out = "%s/%s.html" % (head, post_title)
-            if not os.path.exists(head):
-                os.makedirs(head)
-        else:
-            out = "%s.html" % (post_title, )
         post_template.stream(**kwargs).dump(out)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-Jinja2==2.6
-PyYAML==3.10
-argh==0.21.0
-argparse==1.2.1
-docopt==0.6.1
-easywatch==0.0.5
-pathtools==0.1.2
-watchdog==0.6.0
-wsgiref==0.1.2
+Jinja2>=2.6
+PyYAML>=3.10
+argh>=0.21.0
+argparse>=1.2.1
+docopt>=0.6.1
+easywatch>=0.0.5
+pathtools>=0.1.2
+watchdog>=0.6.0
+wsgiref>=0.1.2; python_version < '2.5'

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -33,6 +33,7 @@ def render(args):
                 '--outpath': None,
                 '--srcpath': None,
                 '--static': None,
+                '--srcmask': None,
                 '--version': False,
                 'build': True,
                 'watch': False

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -4,8 +4,8 @@
 """staticjinja
 
 Usage:
-  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c>]
-  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c>]
+  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> --srcmask='*.html']
+  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> --srcmask='*.html']
   staticjinja (-h | --help)
   staticjinja --version
 
@@ -70,10 +70,13 @@ def render(args):
                 print("The static files directory '%s' is invalid." % path)
                 sys.exit(1)
 
+    srcmask = args.get('--srcmask', None)
+
     site = staticjinja.make_site(
         searchpath=srcpath,
         outpath=outpath,
-        staticpaths=staticpaths
+        staticpaths=staticpaths,
+        searchmask=srcmask
     )
 
     use_reloader = args['watch']

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -4,8 +4,10 @@
 """staticjinja
 
 Usage:
-  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> --srcmask='*.html']
-  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> --srcmask='*.html']
+  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> \
+      --srcmask='*.html']
+  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c> \
+      --srcmask='*.html']
   staticjinja (-h | --help)
   staticjinja --version
 

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -73,6 +73,13 @@ class Site(object):
         contexts list will be merged (in order) to get the final context.
         Otherwise, only the first matching regex is used. Defaults to
         ``False``.
+
+    :param searchmask:
+        Unix wildcard such as ``*.html`` that specifies the filemask for
+        templates. If present, only files in searchpath that match this
+        filemask will be loaded as templates, other files will be
+        considered statics.
+
     """
 
     def __init__(self,

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -14,7 +14,7 @@ import os
 import re
 import shutil
 import warnings
-
+from fnmatch import fnmatch
 from jinja2 import Environment, FileSystemLoader
 
 from .reloader import Reloader
@@ -85,6 +85,7 @@ class Site(object):
                  rules=None,
                  staticpaths=None,
                  mergecontexts=False,
+                 searchmask=None,
                  ):
         self._env = environment
         self.searchpath = searchpath
@@ -97,6 +98,7 @@ class Site(object):
             warnings.warn("staticpaths are deprecated. Use Make instead.")
         self.staticpaths = staticpaths
         self.mergecontexts = mergecontexts
+        self.searchmask = searchmask
 
     @classmethod
     def make_site(cls,
@@ -111,7 +113,9 @@ class Site(object):
                   filters=None,
                   env_globals=None,
                   env_kwargs=None,
-                  mergecontexts=False):
+                  mergecontexts=False,
+                  searchmask=None,
+                  ):
         """Create a :class:`Site <Site>` object.
 
         :param searchpath:
@@ -210,6 +214,7 @@ class Site(object):
                    contexts=contexts,
                    staticpaths=staticpaths,
                    mergecontexts=mergecontexts,
+                   searchmask=searchmask,
                    )
 
     @property
@@ -284,13 +289,16 @@ class Site(object):
         :param filename: the name of the file to check
 
         """
-        if self.staticpaths is None:
-            # We're not using static file support
-            return False
 
-        for path in self.staticpaths:
-            if filename.startswith(path):
+        if self.staticpaths:
+            for path in self.staticpaths:
+                if filename.startswith(path):
+                    return True
+
+        if self.searchmask:
+            if not fnmatch(filename, self.searchmask):
                 return True
+
         return False
 
     def is_partial(self, filename):
@@ -459,7 +467,9 @@ def make_site(searchpath="templates",
               filters=None,
               env_globals=None,
               env_kwargs=None,
-              mergecontexts=False):
+              mergecontexts=False,
+              searchmask=None,
+              ):
     warnings.warn("make_site was renamed to Site.make_site.")
     return Site.make_site(searchpath=searchpath,
                           outpath=outpath,
@@ -472,7 +482,9 @@ def make_site(searchpath="templates",
                           filters=filters,
                           env_globals=env_globals,
                           env_kwargs=env_kwargs,
-                          mergecontexts=mergecontexts)
+                          mergecontexts=mergecontexts,
+                          searchmask=searchmask,
+                          )
 
 
 def make_renderer(*args, **kwargs):


### PR DESCRIPTION
Apart from https://github.com/NickCrews/staticjinja/commit/79512ba753390c21c484650c4dcd41c6e95409c1  and a more robust .gitignore, this PR includes a new `--srcmask` CLI option and a new `searchmask` argument. 

The --srcmask CLI option & searchmask argument let you specify a complementary way to load Jinja templates. When you supply --srcmask='*.html', only the .html files in the srcpath will be loaded as Jinja2 templates, while all other files will be loaded as statics. All files in --static will also be loaded as statics.