### PR TITLE
Fixes cross-platform support due to Jinja2 FileSystemLoader.list_templates

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Patches and Suggestions
 - Anuraag Agrawal (anuraaga)
 - saschalalala
 - Tim Best (timbest)
+- Fasih Ahmad Fakhri

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -274,39 +274,39 @@ class Site(object):
                 return render_func
         raise ValueError("no matching rule")
 
-    def is_static(self, filename):
-        """Check if a file is a static file. Static files are copied, rather
-        than compiled using Jinja2.
+    def is_static(self, template_name):
+        """Check if a template is a static template. Static template are copied,
+        rather than compiled using Jinja2.
 
-        A file is considered static if it lives in any of the directories
+        A template is considered static if it lives in any of the directories
         specified in ``staticpaths``.
 
-        :param filename: the name of the file to check
+        :param template_name: the name of the template to check
 
         """
-        return any(filename.startswith(path) for path in self.staticpaths)
+        return any(template_name.startswith(path) for path in self.staticpaths)
 
-    def is_partial(self, filename):
-        """Check if a file is a partial. Partial files are not rendered,
-        but they are used in rendering templates.
+    def is_partial(self, template_name):
+        """Check if a template is a partial template. Partial templates are not
+        rendered, but they are used in rendering templates.
 
-        A file is considered a partial if it or any of its parent directories
-        are prefixed with an ``'_'``.
+        A template is considered a partial if it or any of its parent
+        directories are prefixed with an ``'_'``.
 
-        :param filename: the name of the file to check
+        :param template_name: the name of the template to check
         """
-        return any((x.startswith("_") for x in filename.split(os.path.sep)))
+        return any((x.startswith("_") for x in template_name.split("/")))
 
-    def is_ignored(self, filename):
-        """Check if a file is an ignored file. Ignored files are neither
-        rendered nor used in rendering templates.
+    def is_ignored(self, template_name):
+        """Check if a template is an ignored template. Ignored templates are
+        neither rendered nor used in rendering templates.
 
-        A file is considered ignored if it or any of its parent directories
+        A template is considered ignored if it or any of its parent directories
         are prefixed with an ``'.'``.
 
-        :param filename: the name of the file to check
+        :param template_name: the name of the template to check
         """
-        return any((x.startswith(".") for x in filename.split(os.path.sep)))
+        return any((x.startswith(".") for x in template_name.split("/")))
 
     def is_template(self, filename):
         """Check if a file is a template.
@@ -398,11 +398,13 @@ class Site(object):
 
         :param filename: the name of the file to find dependencies of
         """
-        if self.is_partial(filename):
+        template_name = filename.replace(os.path.sep, "/")
+
+        if self.is_partial(template_name):
             return self.templates
-        elif self.is_template(filename):
+        elif self.is_template(template_name):
             return [self.get_template(filename)]
-        elif self.is_static(filename):
+        elif self.is_static(template_name):
             return [filename]
         else:
             return []

--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -31,6 +31,8 @@ def site(template_path, build_path):
     template_path.join('template1.html').write('Test 1')
     template_path.join('template2.html').write('Test 2')
     template_path.mkdir('sub').join('template3.html').write('Test {{b}}')
+    template_path.mkdir('sub1').join('.ignored2.html').write('Ignored 2')
+    template_path.mkdir('sub2').join('_partial2.html').write('Partial 2')
     template_path.join('template4.html').write('Test {{b}} and {{c}}')
     template_path.mkdir('static_css').join('hello.css').write(
         'a { color: blue; }'
@@ -202,11 +204,15 @@ def test_regular_file_is_not_ignored(site):
 
 
 def test_ignored_file_in_directory_is_ignored(site):
-    assert site.is_ignored(os.sep.join(['.bar', 'index.html']))
+    assert site.is_ignored('/'.join(['.bar', 'index.html']))
 
 
 def test_ignored_file_in_nested_directory_is_ignored(site):
-    assert site.is_ignored(os.sep.join(['foo', '.bar', 'index.html']))
+    assert site.is_ignored('/'.join(['foo', '.bar', 'index.html']))
+
+
+def test_ignored_file_in_normal_nested_directory_is_ignored(site):
+    assert site.is_ignored('/'.join(['foo', 'bar', '.index.html']))
 
 
 def test_partial_file_is_partial(site):
@@ -218,11 +224,15 @@ def test_regular_file_is_not_partial(site):
 
 
 def test_partial_file_in_directory_is_partial(site):
-    assert site.is_partial(os.sep.join(['_bar', 'index.html']))
+    assert site.is_partial('/'.join(['_bar', 'index.html']))
 
 
 def test_partial_file_in_nested_directory_is_partial(site):
-    assert site.is_partial(os.sep.join(['foo', '_bar', 'index.html']))
+    assert site.is_partial('/'.join(['foo', '_bar', 'index.html']))
+
+
+def test_partial_file_in_normal_nested_directory_is_partial(site):
+    assert site.is_partial('/'.join(['foo', 'bar', '_index.html']))
 
 
 @mock.patch('os.path.isdir')


### PR DESCRIPTION
Since Jinja2 template name is always directory delimited with "/"
Hence fixing issue mentioned at #88 