### PR TITLE
Remove PyYAML dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Jinja2==2.6
-PyYAML==3.10
 argh==0.21.0
 argparse==1.2.1
 docopt==0.6.1


### PR DESCRIPTION
Dependabot was throwing a warning that this dependency with its old version was a security problem, but I don't think we actually even need pyYAML, I don't see where we ever use it directly.