### PR TITLE
Make ReadTheDocs build docs correctly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,15 @@ staticjinja
 
 .. image:: https://badge.fury.io/py/staticjinja.png
     :target: http://badge.fury.io/py/staticjinja
+    :alt: PyPi Badge
 
 .. image:: https://travis-ci.com/staticjinja/staticjinja.svg?branch=main
     :target: https://travis-ci.com/staticjinja/staticjinja
+    :alt: Travis CI status
+
+.. image:: https://readthedocs.org/projects/staticjinja/badge/?version=stable
+    :target: https://staticjinja.readthedocs.io/en/stable/?badge=stable&style=plastic
+    :alt: Documentation Status
 
 **staticjinja** is a library that makes it easy to build static sites using
 Jinja2_.


### PR DESCRIPTION
I'm new to this, so not totally sure how everything is fitting together, but builds were failing on https://readthedocs.org/projects/staticjinja. I think adding this config was the solution.

Still seems to be an issue where the ["stable" version of the docs](https://staticjinja.readthedocs.io/en/stable) is pointing to a really old version, tag `0.08`. It should be updated to the latest tagged version per https://docs.readthedocs.io/en/stable/versions.html, but IDK. Maybe there is some time lag with their servers, and ReadTheDocs will pick up that I just added the `0.3.5` and `v0.3.5` tags (IDK if the `v` is important/messes things up with their versioning parsing so I tried both)