### PR TITLE
Remove `staticjinja.make_site` from docs.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,13 +7,8 @@ Developer Interface
 
 This part of the documentation covers staticjinja's API.
 
-Main Interface
---------------
-
-All of staticjinja's functionality can be accessed by this function,
-which returns an instance of the :class:`Site <Site>` object.
-
-.. autofunction:: make_site
+Most of staticjinja's functionality can be accessed with
+:meth:`Site.make_site`, so pay particular attention to that.
 
 Classes
 ~~~~~~~

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -436,6 +436,10 @@ class Site(object):
 
 class Renderer(Site):
     def __init__(self, *args, **kwargs):
+        """
+        .. deprecated:: 0.3.1
+           Use :meth:`Site.make_site` instead.
+        """
         warnings.warn("Renderer was renamed to Site.")
         super(Renderer, Site).__init__(*args, **kwargs)
 
@@ -444,10 +448,18 @@ class Renderer(Site):
 
 
 def make_site(*args, **kwargs):
+    """
+    .. deprecated:: 0.3.4
+       Use :meth:`Site.make_site` instead.
+    """
     warnings.warn("make_site was renamed to Site.make_site.")
     return Site.make_site(*args, **kwargs)
 
 
 def make_renderer(*args, **kwargs):
+    """
+    .. deprecated:: 0.3.1
+       Use :meth:`Site.make_site` instead.
+    """
     warnings.warn("make_renderer was renamed to Site.make_site.")
     return make_site(*args, **kwargs)


### PR DESCRIPTION
If it's deprecated then let's not even mention it.

Also add deprecated notes to the docstrings.