### PR TITLE
Remove python2 syntax using 2to3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ accepted:
   with it.
 - Update all documentation that would be affected by your
   contribution.
-- Make sure your code passes all `tox` and Travis checks.
+- Make sure your code passes all `tox` checks locally, and all GitHub Actions
+  checks on your PR.
 - Ideally, make sure your commit messages are in the proper format:
 
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,8 +51,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'staticjinja'
-copyright = u'2014, Ceasar Bautista'
+project = 'staticjinja'
+copyright = '2014, Ceasar Bautista'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -190,8 +190,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'staticjinja.tex', u'staticjinja Documentation',
-   u'Ceasar Bautista', 'manual'),
+  ('index', 'staticjinja.tex', 'staticjinja Documentation',
+   'Ceasar Bautista', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -220,8 +220,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'staticjinja', u'staticjinja Documentation',
-     [u'Ceasar Bautista'], 1)
+    ('index', 'staticjinja', 'staticjinja Documentation',
+     ['Ceasar Bautista'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -234,8 +234,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'staticjinja', u'staticjinja Documentation',
-   u'Ceasar Bautista', 'staticjinja', 'One line description of project.',
+  ('index', 'staticjinja', 'staticjinja Documentation',
+   'Ceasar Bautista', 'staticjinja', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/staticjinja/__init__.py
+++ b/staticjinja/__init__.py
@@ -16,9 +16,6 @@ https://github.com/staticjinja/staticjinja/
 """
 
 # flake8: noqa
-
-from __future__ import absolute_import
-
 from .version import __version__, __version_info__
 
 from .reloader import Reloader

--- a/staticjinja/__main__.py
+++ b/staticjinja/__main__.py
@@ -3,9 +3,9 @@
 
 import os
 
-from . import staticjinja
+from .staticjinja import Site
 
 if __name__ == "__main__":
     searchpath = os.path.join(os.getcwd(), 'templates')
-    site = staticjinja.make_site(searchpath=searchpath)
+    site = Site.make_site(searchpath=searchpath)
     site.render(use_reloader=True)

--- a/staticjinja/__main__.py
+++ b/staticjinja/__main__.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
-from __future__ import absolute_import
-
 import os
 
-import staticjinja
+from . import staticjinja
 
 if __name__ == "__main__":
     searchpath = os.path.join(os.getcwd(), 'templates')

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -14,11 +14,13 @@ Options:
   --version     Show version.
 
 """
-from __future__ import print_function
-from docopt import docopt
 import os
-from staticjinja import Site, __version__
 import sys
+
+from docopt import docopt
+
+from .staticjinja import Site
+from .version import __version__
 
 
 def render(args):
@@ -45,8 +47,7 @@ def render(args):
     )
 
     if not os.path.isdir(srcpath):
-        print("The templates directory '%s' is invalid."
-              % srcpath)
+        print("The templates directory '{}' is invalid.".format(srcpath))
         sys.exit(1)
 
     if args['--outpath'] is not None:
@@ -62,7 +63,8 @@ def render(args):
         for path in staticpaths:
             path = os.path.join(srcpath, path)
             if not os.path.isdir(path):
-                print("The static files directory '%s' is invalid." % path)
+                print("The static files directory '{}' is"
+                      "invalid.".format(path))
                 sys.exit(1)
 
     site = Site.make_site(

--- a/staticjinja/reloader.py
+++ b/staticjinja/reloader.py
@@ -40,7 +40,7 @@ class Reloader(object):
         """
         filename = os.path.relpath(src_path, self.searchpath)
         if self.should_handle(event_type, src_path):
-            print("%s %s" % (event_type, filename))
+            print("{} {}".format(event_type, filename))
             if self.site.is_static(filename):
                 files = self.site.get_dependencies(filename)
                 self.site.copy_static(files)

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -6,8 +6,6 @@ Simple static page generator.
 Uses Jinja2 to compile templates.
 """
 
-from __future__ import absolute_import
-
 import inspect
 import logging
 import os

--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -1,9 +1,6 @@
 import os
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+import unittest.mock as mock
 from pytest import fixture, raises
 
 from staticjinja import cli, Site, Reloader


### PR DESCRIPTION
I used `2to3 -w -n -f all .` and then did a couple manual tweaks.

The mock library is available in the standard library as unittest.mock from python3.3 onwards.