### PR TITLE
Add PR check from codecov.io

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+# Maybe block PRs that don't have enough coverage.
+coverage:
+  status:
+    project:
+      default:
+        # Fail if coverage drops from base commit.
+        # Use your judgement, maybe ignore this check.
+        target: auto


### PR DESCRIPTION
If the code coverage drops from the base commit, then fail this check. Use your judgement, and ignore this check if wise.