### PR TITLE
dev: Ignore reformating to Black in `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# To ignore the following commits when running `git blame` (useful
+# for ignoring bulk reformats that don't actually change anything), run:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Migrate code style to Black
+f1190228226d5c13a3d7e15e0da9b0fdbec8cb77

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ init:
 	pip3 install poetry
 	# Install dependencies, including dev deps
 	poetry install -E dev
+	# Ignore bulk refactor/reformat changes when running `git blame`
+	git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 black:
 	poetry run black .


### PR DESCRIPTION
Following the advice in https://github.com/psf/black/blob/71117e730c4f62458b30af820f51890487b458e4/README.md#migrating-your-code-style-without-ruining-git-blame

As a help to other devs I included setting git config blame.ignoreRevsFile
 in the `make init` step as well.