### PR TITLE
CLI: Make `python -m staticjinja` redirect to CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ Unreleased_
 
 .. _Unreleased: https://github.com/staticjinja/staticjinja/compare/2.1.0...HEAD
 
+Changed
+^^^^^^^
+
+* Calling ``python3 -m staticjinja`` now works exactly the same as calling
+  ``staticjinja`` directly. If you were using ``python3 -m staticjinja``, this
+  probably broke you, you now need to explicitly give the ``watch`` subcommand
+  with ``python3 -m staticjinja watch``. For more info see
+  https://github.com/staticjinja/staticjinja/issues/152. 
+
 2.1.0_ (2021-06-10)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --doctest-modules --ignore setup.py --basetemp=.pytest
+addopts = -vv --doctest-modules --ignore setup.py --basetemp=.pytest
 testpaths = tests
 
 # Settings for running test coverage, used by pytest coverage plugin

--- a/staticjinja/__main__.py
+++ b/staticjinja/__main__.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
-import os
-
-from .staticjinja import Site
+from .cli import main
 
 if __name__ == "__main__":
-    searchpath = os.path.join(os.getcwd(), "templates")
-    site = Site.make_site(searchpath=searchpath)
-    site.render(use_reloader=True)
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock as mock
+import subprocess
 
 import pytest
 
@@ -96,3 +97,32 @@ def test_nonexistent_srcpath(mock_make_site):
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
     mock_make_site.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["staticjinja"],
+        ["python3", "-m", "staticjinja"],
+    ],
+)
+def test_entrypoints_no_args(command):
+    """Ensure we can access the staticjinja CLI from the shell.
+
+    Don't bother testing for any complex inputs or outputs, this is just to
+    ensure that the entrypoints are properly installed.
+    """
+    result = subprocess.run(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5
+    )
+    expected_help_message = b"""Usage:
+  staticjinja build [options]
+  staticjinja watch [options]
+  staticjinja -h | --help
+  staticjinja --version
+""".replace(
+        b"\n", os.linesep.encode("utf8")
+    )
+    assert result.returncode == 1
+    assert result.stdout == b""
+    assert result.stderr == expected_help_message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import unittest.mock as mock
 import subprocess
+import sys
 
 import pytest
 
@@ -103,7 +104,7 @@ def test_nonexistent_srcpath(mock_make_site):
     "command",
     [
         ["staticjinja"],
-        ["python3", "-m", "staticjinja"],
+        [sys.executable, "-m", "staticjinja"],
     ],
 )
 def test_entrypoints_no_args(command):


### PR DESCRIPTION
See https://github.com/staticjinja/staticjinja/issues/152.
If this breaks your code, then to get back to the old behavior
you should just change your use of `python3 -m staticjinja` to
`python3 -m staticjinja watch`