### PR TITLE
Fix build status badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '0 0 * * 0' # weekly, to catch exterior dependencies changing
+    - cron: "0 0 * * *" # daily
 
 jobs:
   test:
@@ -22,70 +22,70 @@ jobs:
         #  - os: macos-latest
         #    python-version: 3.6:
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: make init
-    # Run tox using the version of Python in `PATH`
-    - name: Run tests in tox
-      run: poetry run tox -e py
-    # Upload pytest's scratch space, which was set to .pytest/ in setup.cfg
-    # Useful for debugging.
-    - name: Upload pytest tmpdir
-      uses: actions/upload-artifact@v2
-      if: failure() # Only upload on failure of previous step.
-      with:
-        name: pytest-tmpdir ${{ matrix.python-version }} ${{ matrix.os }}
-        path: .pytest/
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: make init
+      # Run tox using the version of Python in `PATH`
+      - name: Run tests in tox
+        run: poetry run tox -e py
+      # Upload pytest's scratch space, which was set to .pytest/ in setup.cfg
+      # Useful for debugging.
+      - name: Upload pytest tmpdir
+        uses: actions/upload-artifact@v2
+        if: failure() # Only upload on failure of previous step.
+        with:
+          name: pytest-tmpdir ${{ matrix.python-version }} ${{ matrix.os }}
+          path: .pytest/
   black:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x' # Latest python release
-    - name: Install dependencies
-      run: make init
-    - name: Check that we conform to black
-      run: make black-check
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x" # Latest python release
+      - name: Install dependencies
+        run: make init
+      - name: Check that we conform to black
+        run: make black-check
   flake8:
     # Only run the linter on a single python version on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x' # Latest python release
-    - name: Install dependencies
-      run: make init
-    - name: Run flake8
-      run: make flake8
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x" # Latest python release
+      - name: Install dependencies
+        run: make init
+      - name: Run flake8
+        run: make flake8
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x' # Latest python release
-    - name: Install dependencies
-      run: make init
-    - name: Build docs
-      run: make docs
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x" # Latest python release
+      - name: Install dependencies
+        run: make init
+      - name: Build docs
+        run: make docs
   coverage:
     # Only run test coverage on a single python version on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x' # Latest python release
-    - name: Install dependencies
-      run: make init
-    - name: Measure test coverage and upload results
-      run: make coverage-upload
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x" # Latest python release
+      - name: Install dependencies
+        run: make init
+      - name: Measure test coverage and upload results
+        run: make coverage-upload

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ staticjinja
     :target: https://badge.fury.io/py/staticjinja
     :alt: PyPi Badge
 
-.. image:: https://github.com/staticjinja/staticjinja/workflows/build/badge.svg?branch=main&event=push
+.. image:: https://github.com/staticjinja/staticjinja/workflows/build/badge.svg?branch=main&event=schedule
     :target: https://github.com/staticjinja/staticjinja/actions?query=branch%3Amain
     :alt: Build and Testing Status
 


### PR DESCRIPTION
Before it was always pointing to the lastest `push` to `main`, but that always showed broken whenever a
release is made. (n a release I update the
changelog and add in some links that don't exist
yet, and the docs test step catches these bad links.
The links only are valid once the `tag` action comes along
and actually tags the release.

Now, make the badge show the status for the CI runs that
happen every day. These will show green since after the
`tag` action runs right after push, the links exist
and the docs check is happy.

Anyway, it's just an annoying detail, and this isn't a perfect fix, but
for 90% of people who look at the badge status it should
be correct.