### PR TITLE
Allow nested paths to be created automatically

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Patches and Suggestions
 - saschalalala
 - Tim Best (timbest)
 - Fasih Ahmad Fakhri
+- zakx

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -32,7 +32,7 @@ def _compute_context(context_like, template):
 
 def _ensure_dir(path):
     """Ensure the directory for a file exists."""
-    Path(path).parent.mkdir(exist_ok=True)
+    Path(path).parent.mkdir(exist_ok=True, parents=True)
 
 
 def get_build_script_directory():


### PR DESCRIPTION
simplejinja is currently unable to build a project with nested directories:

```Traceback (most recent call last):
  File ".env/bin/staticjinja", line 8, in <module>
    sys.exit(main())
  File ".env/lib/python3.9/site-packages/staticjinja/cli.py", line 90, in main
    render(docopt(__doc__, argv=argv, version=staticjinja.__version__))
  File ".env/lib/python3.9/site-packages/staticjinja/cli.py", line 84, in render
    site.render(use_reloader=args["watch"])
  File ".env/lib/python3.9/site-packages/staticjinja/staticjinja.py", line 475, in render
    self.render_templates(self.templates)
  File ".env/lib/python3.9/site-packages/staticjinja/staticjinja.py", line 424, in render_templates
    self.render_template(template)
  File ".env/lib/python3.9/site-packages/staticjinja/staticjinja.py", line 412, in render_template
    _ensure_dir(filepath)
  File ".env/lib/python3.9/site-packages/staticjinja/staticjinja.py", line 35, in _ensure_dir
    Path(path).parent.mkdir(exist_ok=True)
  File "/usr/local/Cellar/python@3.9/3.9.7_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/pathlib.py", line 1323, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: 'build/aktuelles/artikel'
```

This PR fixes that by allowing pathlib to create missing parent folders.