### PR TITLE
Allow workflows to be triggered manually.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,40 +1,41 @@
 name: publish
 on:
+  workflow_dispatch:
   push:
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "[0-9]+.[0-9]+.[0-9]+"
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up latest Python 3
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: make init
-    - name: Build package
-      run: make build
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
-      with:
-        user: '__token__'
-        password: ${{ secrets.PYPI_API_TOKEN }}
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
+      - uses: actions/checkout@v2
+      - name: Set up latest Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: make init
+      - name: Build package
+        run: make build
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: "__token__"
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
           # secrets.GITHUB_TOKEN is provided by GitHub.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: See CHANGELOG.rst
-        draft: false
-        prerelease: false
-    - name: Upload dist/ as workflow artifact (mostly for debugging)
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: See CHANGELOG.rst
+          draft: false
+          prerelease: false
+      - name: Upload dist/ as workflow artifact (mostly for debugging)
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,6 @@
 name: tag
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
When I created a github release in the webui,
the publish workflow didn't run so the new release wasnt
sent to pypi. I want to be
able to do this manually.