### PR TITLE
Support list of outputs in contexts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,4 @@ Patches and Suggestions
 - Tim Best (timbest)
 - Fasih Ahmad Fakhri
 - zakx
+- Sol Bekic (s-ol)

--- a/staticjinja/types.py
+++ b/staticjinja/types.py
@@ -14,19 +14,22 @@ FilePath: te.TypeAlias = "str | Path"
 PageMapping: te.TypeAlias = "list[tuple[str, _T]]"
 
 Context: te.TypeAlias = "dict[str, t.Any]"
+ContextMulti: te.TypeAlias = "list[tuple[str | None, Context]]"
 
 
 class ContextCallable(te.Protocol):
-    def __call__(self) -> Context:
+    def __call__(self) -> Context | ContextMulti:
         ...
 
 
 class ContextTemplateCallable(te.Protocol):
-    def __call__(self, __template: Template) -> Context:
+    def __call__(self, __template: Template) -> Context | ContextMulti:
         ...
 
 
-ContextLike: te.TypeAlias = "Context | ContextCallable | ContextTemplateCallable"
+ContextLike: te.TypeAlias = (
+    "Context | ContextMulti | ContextCallable | ContextTemplateCallable"
+)
 
 
 class Rule(te.Protocol):


### PR DESCRIPTION
This implements multiple outputs from a single context handler as per [my comment in #72](https://github.com/staticjinja/staticjinja/issues/72#issuecomment-1976344826).

This passes the existing test suite and a `get_context()` method with the original signature was kept alongside the new `get_contexts()` used internally to support legacy user code.

It would probably be a good idea to add tests for the context merging logic, as well as a usage example.